### PR TITLE
Added a bitnami annotation that couses automaticaly created secrets

### DIFF
--- a/docs/deployment-and-infrastructure/secrets.md
+++ b/docs/deployment-and-infrastructure/secrets.md
@@ -19,6 +19,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: database-secret
+annotation:
+  sealedsecrets.bitnami.com/managed: "true"
 data:
   POSTGRES_DB: YmFuYW5h
   POSTGRES_USER: YmFuYW5h
@@ -26,7 +28,7 @@ data:
 ```
 
 - `metadata.name` is the name of the group of secrets in our case, `database-secret` - if this is app specific, it is often prefix by app name, so for example `bratislava-strapi-database-secret`
-
+- `annotation/sealedsecrets.bitnami.com` automatically creates "unsealed" secret inside k8 cluster, managed by the bitnami secret plugin
 - `data` contains environment variables keys (`POSTGRES_DB`) and base64 encode values (`YmFuYW5h`).
 
 For example, if you need to set up the database name to `banana`, you need to base64 encode this value. You can use an online base64 converter like https://www.base64encode.org and encode `banana` to `YmFuYW5h`. This has to happen even if the value you want to provide is base64 encoded! In such case you'll take your base64 encoded value and encode it again.
@@ -69,4 +71,39 @@ which after base64 encoding looks like this:
 POSTGRES_DB: bmVzdC1wcmlzbWEtdGVtcGxhdGU=
 POSTGRES_USER: bmVzdC1wcmlzbWEtdGVtcGxhdGU=
 POSTGRES_PASSWORD: TEJjZHNvMDhiJmFhc2QoY2syKmQhcA==
+```
+
+
+### Tips & Tricks
+
+If you don't need special settings for your secret, you can create entire `kubesealed` secret by running following command:
+
+```bash
+ kubectl create secret generic <SECRET_NAME> --from-literal=<KEY>=<VALUE> --dry-run=client -o json \
+ | jq '. += { "annotation": {"sealedsecrets.bitnami.com/managed": "true"} }' \
+ | kubeseal --controller-name=sealed-secrets --scope=namespace-wide -o yaml --namespace=<NAMESPACE>
+```
+
+Sticking with our banana example, we create a `database-secret` with "banana" user, password and DB in namespace `"standalone"` and push it to the file name `database.secret.yml`:
+
+```bash
+ kubectl create secret generic database-secret \
+    --from-literal=POSTGRES_DB=banana \
+    --from-literal=POSTGRES_USER=banana \
+    --from-literal=POSTGRES_PASSWORD=banana \
+  --dry-run=client -o json \
+ | jq '. += { "annotation": {"sealedsecrets.bitnami.com/managed": "true"} }' \
+ | kubeseal --controller-name=sealed-secrets --scope=namespace-wide -o yaml --namespace=standalone > database.secret.yml
+```
+
+*Note, you may need to install [`jq`](https://stedolan.github.io/jq/) by standard means like*
+
+```bash
+brew install jq
+```
+
+*or Debian based*
+
+```bash
+apt install jq
 ```


### PR DESCRIPTION
* Added annotation to the examples that forces a bitnami plugin to create unsealed secret in kubernetes, without user intervention
* Added a one-liner on how to create a sealed secret from cmd