### PR TITLE
Fix the link target for the Innovations Team

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -129,7 +129,7 @@ const config = {
               },
               {
                 label: "Innovations Team",
-                href: "https://github.com/facebook/docusaurus",
+                href: "https://inovacie.bratislava.sk/",
               },
               {
                 label: "Bratislava official page",


### PR DESCRIPTION
The link was pointing to the Docusaurus upstream, contrary to what the link text said.